### PR TITLE
cmsrequest: Added getDomains method

### DIFF
--- a/app/Http/Controllers/CMSController.php
+++ b/app/Http/Controllers/CMSController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Domain;
+use Symfony\Component\HttpFoundation\Response;
+
+class CMSController extends Controller
+{
+    /**
+     * @param int $number
+     * @return Response
+     */
+    public function getDomains(int $number): Response
+    {
+        $domains = Domain::select("domain")->whereNull('cms_principal')->limit($number)->get();
+        $domainsParsed = [];
+        foreach ($domains as $domain) {
+            $domainsParsed[] = $domain['domain'];
+        }
+        return new Response(json_encode($domainsParsed), 200, ['content-type' => 'application/json']);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CMSController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -17,3 +18,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::post('/cmsrequest/{number}', [CMSController::class, 'getDomains']);


### PR DESCRIPTION
Se ha añadido un nuevo controlador con una nueva función que busca el numero de dominios sin cms identificado que indiques en la petición y los devuelve en formato array.

# JUEGO DE PRUEBAS
DESCRIPCION|IMAGEN
---|---
Registros de prueba que he creado en la base de datos en local|![image](https://user-images.githubusercontent.com/91798117/233121823-f2cf28d0-7e30-48bb-91d7-1506138c92e3.png)
Resultado cuando hago la petición para que me devuelva un dominio|![image](https://user-images.githubusercontent.com/91798117/233122066-1b101d1f-b15e-4081-b564-ebc8e91a6355.png)
Resultado para que me devuelva 2|![image](https://user-images.githubusercontent.com/91798117/233122310-3f29fe9f-e60b-4cac-8387-828d90704416.png)
Resultado para mas de 2 que en este caso es mas de los que tengo en la base de datos(No da error por lo que entiendo que esta bien)|![image](https://user-images.githubusercontent.com/91798117/233122580-e7cbcc9c-739a-48f4-aad0-2a11e40dd325.png)
