### PR TITLE
cmsupdate: Added endpoint for updating cms on domains

### DIFF
--- a/app/Http/Controllers/CMSController.php
+++ b/app/Http/Controllers/CMSController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Domain;
+use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class CMSController extends Controller
@@ -20,4 +21,18 @@ class CMSController extends Controller
         }
         return new Response(json_encode($domainsParsed), 200, ['content-type' => 'application/json']);
     }
+
+    /**
+     * @param Request $request
+     * @return Response
+     */
+    public function setCMSName(Request $request): Response
+    {
+        if ($request->get('domain') !== null && $request->get('cms') !== null) {
+            Domain::where('domain', $request->get('domain'))->update(['cms_principal' => $request->get('cms')]);
+            return new Response(json_encode(['status' => 'Datos añadidos correctamente']), 200, ['content-type' => 'application/json']);
+        }
+        return new Response(json_encode(['status' => "Algún dato no es correcto"]), 400, ['content-type' => 'application/json']);
+    }
+
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,3 +20,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::post('/cmsrequest/{number}', [CMSController::class, 'getDomains']);
+Route::post('/cmsupdate', [CMSController::class, 'setCMSName']);


### PR DESCRIPTION
Este endpoint recibe un JSON y con los datos recibidos, se actualiza la fila en la tabla de dominios correspondiente al dominio enviado, actualizando el nombre del CMS.

# JUEGO DE PRUEBAS
DESCRIPCION|IMAGEN
---|---
Datos de prueba en la base de datos local|![image](https://user-images.githubusercontent.com/91798117/233132240-40684f7e-8f84-425e-9798-06cab87d38df.png)
Actualizo un dominio|![image](https://user-images.githubusercontent.com/91798117/233132433-8551f220-e2bf-4cb2-b4ca-4ead9ac24d0f.png)![image](https://user-images.githubusercontent.com/91798117/233132509-e95a1c09-58dc-461a-9691-4804368048cf.png)
Si envío un dato erroneo|![image](https://user-images.githubusercontent.com/91798117/233132674-b8b34c92-55c5-44df-af9d-7dddd87e4327.png)

No he dejado la posibilidad del nullable, es decir, si no envias dominio y cms, respondera con estado 400 y un error en los datos como se puede ver en la imagen.
